### PR TITLE
The role is now compatible with ansible 2.9

### DIFF
--- a/tasks/create_deploy_user.yml
+++ b/tasks/create_deploy_user.yml
@@ -17,6 +17,4 @@
     path: "{{ getent_passwd[django_deployment_user][4] }}"
     state: directory
     mode: "u+rx,g+rx"
-  when: (check_deploy_user_getent|succeeded) and (ansible_distribution=="Ubuntu")
-
-  
+  when: (check_deploy_user_getent is succeeded) and (ansible_distribution=="Ubuntu")


### PR DESCRIPTION
I am not sure since when, but at least with ansible 2.9 `succeeded` doesn't work as a filter anymore, so one has to use `is succeeded` instead. As I have checked this is backward compatible with ansible 2.7.
