### PR TITLE
Added support for PostgresQL database deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,23 @@ Role Variables
 |----------|---------|---------|
 |`django_deployment_user` | **required** | the user that will perform the deployments |
 |`webserver`| `nginx` | the type of webserver serving the application (in front of uWSGI). Supported values are `apache2` and `nginx`|
+|`database`| `sqlite` | the database required by the application. Supported values are `sqlite3` and `postgresql` |
 |`django_deployment_user_ssh_public_key`| **required** | the ssh key of the deployment user|
 |`host_additional_packages`| `[]` | additional packages to install on the host, if your web application needs eg. `rabbitmq`|
 |`python_major`| **required** (defaults to `2`) | Major version of python|
+|`postgresql_version`| **required** if database set to `"postgresql"` | postgresql version. This is necessary to work around cluster creation bug on Ubuntu 18.04|
 
 After deployment, the user will not be allowed to change *his* home folder content.
 
 ### Notes
-This role is just a preliminary host setup for the `raffienficiaud.ansible-django-webapp-deployment-role` role. 
+This role is just a preliminary host setup for the `raffienficiaud.ansible-django-webapp-deployment-role` role.
 Some design choices:
 
 * the design is such that it is possible to deploy several applications on the same server
 * the link between the web server and uWSGI is through Unix sockets (better performances)
 * the role uses uWSGI for making the link between the webserver (Apache or NGinx) and the Django application. Only Debian/Ubuntu
   packages (uWSGI, NGinx/Apache) is supported.
-* the role has support for both python2 and python3. Only required packages are installed by this role. For Python3 only versions 
+* the role has support for both python2 and python3. Only required packages are installed by this role. For Python3 only versions
   that have support for packages `venv` and `pip` are supported (`>= python 3.3`).
 * django 2.0+ requires python3
 * the SSH key can be installed later, depending on the needs, it should only be able to execute the deployment script and copy files

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@
 # default webserver in front of django
 webserver: nginx
 
+# default database backend
+database: sqlite3
+
 # major python version
 python_major: 2
 

--- a/tasks/create_deploy_user.yml
+++ b/tasks/create_deploy_user.yml
@@ -17,6 +17,4 @@
     path: "{{ getent_passwd[django_deployment_user][4] }}"
     state: directory
     mode: "u+rx,g+rx"
-  when: (check_deploy_user_getent|succeeded) and (ansible_distribution=="Ubuntu")
-
-  
+  when: (check_deploy_user_getent is succeeded) and (ansible_distribution=="Ubuntu")

--- a/tasks/deploy_user_permissions.yml
+++ b/tasks/deploy_user_permissions.yml
@@ -1,7 +1,7 @@
-# Grants particular rights on the system for the deployment user. 
+# Grants particular rights on the system for the deployment user.
 
-# sudoers configuration for the deployment agent: this one allows the deployment user
-# to restart uWSGI
+# sudoers configuration for the deployment agent: this one allows the
+# deployment user to restart uWSGI and run psql as postgres user.
 - block:
   - name: make the deployment agent be able to restart UWSGI
     template: >

--- a/tasks/packages_install.yml
+++ b/tasks/packages_install.yml
@@ -24,6 +24,19 @@
     - python3-venv
   when: python_major==3
 
+- name: install sqlite database on the host
+  apt: name="sqlite3" update_cache=yes state=present cache_valid_time=3600
+  when: database=="sqlite3"
+
+- block:
+  - name: install postgres database on the host
+    apt: name="postgresql-{{postgresql_version}}" update_cache=yes state=present cache_valid_time=3600
+
+  - name: create postgres cluster (automatic creation during installation fails)
+    shell: pg_createcluster {{postgresql_version}} main --start || true
+
+  when: database=="postgresql"
+
 - block:
   - name: install Apache on the host
     apt: name="{{ item }}" update_cache=yes state=present cache_valid_time=3600

--- a/tasks/packages_install.yml
+++ b/tasks/packages_install.yml
@@ -32,6 +32,9 @@
   - name: install postgres database on the host
     apt: name="postgresql-{{postgresql_version}}" update_cache=yes state=present cache_valid_time=3600
 
+  - name: install python package
+    apt: name="python3-psycopg2" update_cache=yes state=present cache_valid_time=3600
+
   - name: create postgres cluster (automatic creation during installation fails)
     shell: pg_createcluster {{postgresql_version}} main --start || true
 

--- a/templates/etc/sudoers.d/deploymentagent_services_restart.j2
+++ b/templates/etc/sudoers.d/deploymentagent_services_restart.j2
@@ -1,1 +1,1 @@
-{{ django_deployment_user }} ALL=(ALL) NOPASSWD: /etc/init.d/uwsgi
+{{ django_deployment_user }} ALL=(ALL) NOPASSWD: /etc/init.d/uwsgi, /usr/bin/psql


### PR DESCRIPTION
Now we have an option to prepare the machine with PostgresQL installed. In this particular role we only install the system package and create a default cluster. No database setup and access control is done in here.